### PR TITLE
Rename recordChatPredictions to recordUserPredictions in analyrics

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,7 @@ ij_visual_guides = none
 ij_wrap_on_typing = false
 
 [*.java]
+indent_style = tab
 ij_java_align_consecutive_assignments = false
 ij_java_align_consecutive_variable_declarations = false
 ij_java_align_group_field_declarations = false

--- a/miner/build.gradle.kts
+++ b/miner/build.gradle.kts
@@ -53,6 +53,8 @@ sourceSets {
             compileClasspath += sourceSets.main.get().compileClasspath
             compileClasspath += sourceSets.main.get().output
 
+            annotationProcessorPath += sourceSets.main.get().annotationProcessorPath
+
             runtimeClasspath += sourceSets.main.get().compileClasspath
             runtimeClasspath += sourceSets.main.get().runtimeClasspath
             runtimeClasspath += sourceSets.main.get().output

--- a/miner/docs/modules/ROOT/examples/global-config-schema.json
+++ b/miner/docs/modules/ROOT/examples/global-config-schema.json
@@ -31,7 +31,7 @@
                       },
                       "jdbcUrl" : {
                         "type" : "string",
-                        "description" : "JDBC connection URL."
+                        "description" : "JDBC connection URL. (supported: mariadb, mysql, sqlite)"
                       },
                       "lifetimeTimeout" : {
                         "type" : "integer",
@@ -59,7 +59,7 @@
                   "type" : "boolean",
                   "description" : "Enable or disable data collection. Default: false"
                 },
-                "recordChatsPredictions" : {
+                "recordUserPredictions" : {
                   "type" : "boolean",
                   "description" : "Record other chat members predictions. Default: false"
                 }
@@ -142,10 +142,13 @@
                               }
                             },
                             "description" : "Always bet the same amount.",
-                            "required" : ["type"]
-                          }, {
-                            "description" : "How to calculate the amount to the bet. Default: percentage(percentage: 20, max: 50000)"
-                          }
+                            "required" : [
+                              "type"
+                            ]
+                          },
+                            {
+                              "description" : "How to calculate the amount to the bet. Default: percentage(percentage: 20, max: 50000)"
+                            }
                           ]
                         }, {
                           "allOf" : [ {
@@ -164,10 +167,13 @@
                               }
                             },
                             "description" : "Place a percentage of your points (with a limit).",
-                            "required" : ["type"]
-                          }, {
-                            "description" : "How to calculate the amount to the bet. Default: percentage(percentage: 20, max: 50000)"
-                          }
+                            "required" : [
+                              "type"
+                            ]
+                          },
+                            {
+                              "description" : "How to calculate the amount to the bet. Default: percentage(percentage: 20, max: 50000)"
+                            }
                           ]
                         } ]
                       },
@@ -185,10 +191,13 @@
                               }
                             },
                             "description" : "Place the bet a certain amount of time before the end of the original prediction.",
-                            "required" : ["type"]
-                          }, {
-                            "description" : "How to calculate when to place the bet. Default: 10s from end"
-                          }
+                            "required" : [
+                              "type"
+                            ]
+                          },
+                            {
+                              "description" : "How to calculate when to place the bet. Default: 10s from end"
+                            }
                           ]
                         }, {
                           "allOf" : [ {
@@ -203,10 +212,13 @@
                               }
                             },
                             "description" : "Place the bet a certain amount of time after the beginning of the original prediction.",
-                            "required" : ["type"]
-                          }, {
-                            "description" : "How to calculate when to place the bet. Default: 10s from end"
-                          }
+                            "required" : [
+                              "type"
+                            ]
+                          },
+                            {
+                              "description" : "How to calculate when to place the bet. Default: 10s from end"
+                            }
                           ]
                         }, {
                           "allOf" : [ {
@@ -221,10 +233,13 @@
                               }
                             },
                             "description" : "Place the bet after 'percent'% of the original timer elapsed.",
-                            "required" : ["type"]
-                          }, {
-                            "description" : "How to calculate when to place the bet. Default: 10s from end"
-                          }
+                            "required" : [
+                              "type"
+                            ]
+                          },
+                            {
+                              "description" : "How to calculate when to place the bet. Default: 10s from end"
+                            }
                           ]
                         } ]
                       },
@@ -298,10 +313,13 @@
                               }
                             },
                             "description" : "Choose the outcome with the most users. However, if the two most picked outcomes have a user count similar, choose the outcome with the least points (higher odds).",
-                            "required" : ["type"]
-                          }, {
-                            "description" : "How to choose what outcome to place the bet on. Default: smart(0.2)"
-                          }
+                            "required" : [
+                              "type"
+                            ]
+                          },
+                            {
+                              "description" : "How to choose what outcome to place the bet on. Default: smart(0.2)"
+                            }
                           ]
                         }, {
                           "allOf" : [ {
@@ -337,10 +355,13 @@
                               }
                             },
                             "description" : "Choose the outcome that's backed by other users with the highest average return-on-investment. Requires analytics to be enabled and recordChatsPredictions to be activated.",
-                            "required" : ["type"]
-                          }, {
-                            "description" : "How to choose what outcome to place the bet on. Default: smart(0.2)"
-                          }
+                            "required" : [
+                              "type"
+                            ]
+                          },
+                            {
+                              "description" : "How to choose what outcome to place the bet on. Default: smart(0.2)"
+                            }
                           ]
                         } ]
                       }
@@ -367,8 +388,11 @@
                           }
                         },
                         "description" : "Adds a constant value to the score of the streamer.",
-                        "required" : ["type"]
-                      }, {
+                        "required" : [
+                          "type"
+                        ]
+                      },
+                      {
                         "type" : "object",
                         "properties" : {
                           "score" : {
@@ -388,8 +412,11 @@
                           }
                         },
                         "description" : "Return a score if the logged-in user is subscribed to the streamer.",
-                        "required" : ["type"]
-                      }, {
+                        "required" : [
+                          "type"
+                        ]
+                      },
+                      {
                         "type" : "object",
                         "properties" : {
                           "score" : {
@@ -405,8 +432,11 @@
                           }
                         },
                         "description" : "Return a score if owned points are above a defined value.",
-                        "required" : ["type"]
-                      }, {
+                        "required" : [
+                          "type"
+                        ]
+                      },
+                      {
                         "type" : "object",
                         "properties" : {
                           "score" : {
@@ -422,8 +452,11 @@
                           }
                         },
                         "description" : "Return a score if owned points are below a defined value.",
-                        "required" : ["type"]
-                      }, {
+                        "required" : [
+                          "type"
+                        ]
+                      },
+                      {
                         "type" : "object",
                         "properties" : {
                           "score" : {
@@ -435,8 +468,11 @@
                           }
                         },
                         "description" : "Return a score if the streamer has a potential watch streak to claim.",
-                        "required" : ["type"]
-                      }, {
+                        "required" : [
+                          "type"
+                        ]
+                      },
+                      {
                         "type" : "object",
                         "properties" : {
                           "score" : {
@@ -448,7 +484,9 @@
                           }
                         },
                         "description" : "Return a score if a drop campaign may be progressed by watching this stream.",
-                        "required" : ["type"]
+                        "required" : [
+                          "type"
+                        ]
                       }
                     ]
                   }
@@ -465,6 +503,10 @@
               "embeds" : {
                 "type" : "boolean",
                 "description" : "Use embeds in the messages or not. Default: false"
+              },
+              "events" : {
+                "type" : "object",
+                "description" : "Customize events that are sent. Key is the name of an event (can be seen in the event/impl package). Default: all events with default format"
               },
               "webhookUrl" : {
                 "type" : "string",
@@ -503,10 +545,13 @@
                   }
                 },
                 "description" : "Deprecated. Login though Twitch's Passport API (web client).",
-                "required" : ["type"]
-              }, {
-                "description" : "Login method to use."
-              }
+                "required" : [
+                  "type"
+                ]
+              },
+                {
+                  "description" : "Login method to use."
+                }
               ]
             }, {
               "allOf" : [ {
@@ -558,10 +603,13 @@
                   }
                 },
                 "description" : "Login though controlled browser (selenium).",
-                "required" : ["type"]
-              }, {
-                "description" : "Login method to use."
-              }
+                "required" : [
+                  "type"
+                ]
+              },
+                {
+                  "description" : "Login method to use."
+                }
               ]
             }, {
               "allOf" : [ {
@@ -584,35 +632,42 @@
                   }
                 },
                 "description" : "Deprecated. Login though Twitch's Passport API (as mobile).",
-                "required" : ["type"]
-              }, {
-                "description" : "Login method to use."
-              }
-              ]
-            }, {
-              "allOf" : [
+                "required" : [
+                  "type"
+                ]
+              },
                 {
-                  "type" : "object",
-                  "properties" : {
-                    "authenticationFolder" : {
-                      "$ref" : "#/$defs/Path",
-                      "description" : "Path to a folder that contains authentication files used to log back in after a restart. Default: ./authentication"
-                    },
-                    "password" : {
-                      "type" : "string",
-                      "description" : "Password of your Twitch account."
-                    },
-                    "type" : {
-                      "const" : "tv"
-                    }
-                  },
-                  "description" : "Login though Twitch's Oauth API (as android tv).",
-                  "required" : ["type"]
-                }, {
                   "description" : "Login method to use."
                 }
               ]
-            }
+            },
+              {
+                "allOf" : [
+                  {
+                    "type" : "object",
+                    "properties" : {
+                      "authenticationFolder" : {
+                        "$ref" : "#/$defs/Path",
+                        "description" : "Path to a folder that contains authentication files used to log back in after a restart. Default: ./authentication"
+                      },
+                      "password" : {
+                        "type" : "string",
+                        "description" : "Password of your Twitch account."
+                      },
+                      "type" : {
+                        "const" : "tv"
+                      }
+                    },
+                    "description" : "Login though Twitch's Oauth API (as android tv).",
+                    "required" : [
+                      "type"
+                    ]
+                  },
+                  {
+                    "description" : "Login method to use."
+                  }
+                ]
+              }
             ]
           },
           "reloadEvery" : {

--- a/miner/docs/modules/ROOT/examples/streamer-config-schema.json
+++ b/miner/docs/modules/ROOT/examples/streamer-config-schema.json
@@ -62,10 +62,13 @@
                   }
                 },
                 "description" : "Always bet the same amount.",
-                "required" : ["type"]
-              }, {
-                "description" : "How to calculate the amount to the bet. Default: percentage(percentage: 20, max: 50000)"
-              }
+                "required" : [
+                  "type"
+                ]
+              },
+                {
+                  "description" : "How to calculate the amount to the bet. Default: percentage(percentage: 20, max: 50000)"
+                }
               ]
             }, {
               "allOf" : [ {
@@ -84,10 +87,13 @@
                   }
                 },
                 "description" : "Place a percentage of your points (with a limit).",
-                "required" : ["type"]
-              }, {
-                "description" : "How to calculate the amount to the bet. Default: percentage(percentage: 20, max: 50000)"
-              }
+                "required" : [
+                  "type"
+                ]
+              },
+                {
+                  "description" : "How to calculate the amount to the bet. Default: percentage(percentage: 20, max: 50000)"
+                }
               ]
             } ]
           },
@@ -105,10 +111,13 @@
                   }
                 },
                 "description" : "Place the bet a certain amount of time before the end of the original prediction.",
-                "required" : ["type"]
-              }, {
-                "description" : "How to calculate when to place the bet. Default: 10s from end"
-              }
+                "required" : [
+                  "type"
+                ]
+              },
+                {
+                  "description" : "How to calculate when to place the bet. Default: 10s from end"
+                }
               ]
             }, {
               "allOf" : [ {
@@ -123,10 +132,13 @@
                   }
                 },
                 "description" : "Place the bet a certain amount of time after the beginning of the original prediction.",
-                "required" : ["type"]
-              }, {
-                "description" : "How to calculate when to place the bet. Default: 10s from end"
-              }
+                "required" : [
+                  "type"
+                ]
+              },
+                {
+                  "description" : "How to calculate when to place the bet. Default: 10s from end"
+                }
               ]
             }, {
               "allOf" : [ {
@@ -141,10 +153,13 @@
                   }
                 },
                 "description" : "Place the bet after 'percent'% of the original timer elapsed.",
-                "required" : ["type"]
-              }, {
-                "description" : "How to calculate when to place the bet. Default: 10s from end"
-              }
+                "required" : [
+                  "type"
+                ]
+              },
+                {
+                  "description" : "How to calculate when to place the bet. Default: 10s from end"
+                }
               ]
             } ]
           },
@@ -218,10 +233,13 @@
                   }
                 },
                 "description" : "Choose the outcome with the most users. However, if the two most picked outcomes have a user count similar, choose the outcome with the least points (higher odds).",
-                "required" : ["type"]
-              }, {
-                "description" : "How to choose what outcome to place the bet on. Default: smart(0.2)"
-              }
+                "required" : [
+                  "type"
+                ]
+              },
+                {
+                  "description" : "How to choose what outcome to place the bet on. Default: smart(0.2)"
+                }
               ]
             }, {
               "allOf" : [ {
@@ -257,10 +275,13 @@
                   }
                 },
                 "description" : "Choose the outcome that's backed by other users with the highest average return-on-investment. Requires analytics to be enabled and recordChatsPredictions to be activated.",
-                "required" : ["type"]
-              }, {
-                "description" : "How to choose what outcome to place the bet on. Default: smart(0.2)"
-              }
+                "required" : [
+                  "type"
+                ]
+              },
+                {
+                  "description" : "How to choose what outcome to place the bet on. Default: smart(0.2)"
+                }
               ]
             } ]
           }
@@ -287,8 +308,11 @@
               }
             },
             "description" : "Adds a constant value to the score of the streamer.",
-            "required" : ["type"]
-          }, {
+            "required" : [
+              "type"
+            ]
+          },
+          {
             "type" : "object",
             "properties" : {
               "score" : {
@@ -308,8 +332,11 @@
               }
             },
             "description" : "Return a score if the logged-in user is subscribed to the streamer.",
-            "required" : ["type"]
-          }, {
+            "required" : [
+              "type"
+            ]
+          },
+          {
             "type" : "object",
             "properties" : {
               "score" : {
@@ -325,8 +352,11 @@
               }
             },
             "description" : "Return a score if owned points are above a defined value.",
-            "required" : ["type"]
-          }, {
+            "required" : [
+              "type"
+            ]
+          },
+          {
             "type" : "object",
             "properties" : {
               "score" : {
@@ -342,8 +372,11 @@
               }
             },
             "description" : "Return a score if owned points are below a defined value.",
-            "required" : ["type"]
-          }, {
+            "required" : [
+              "type"
+            ]
+          },
+          {
             "type" : "object",
             "properties" : {
               "score" : {
@@ -355,8 +388,11 @@
               }
             },
             "description" : "Return a score if the streamer has a potential watch streak to claim.",
-            "required" : ["type"]
-          }, {
+            "required" : [
+              "type"
+            ]
+          },
+          {
             "type" : "object",
             "properties" : {
               "score" : {
@@ -368,7 +404,9 @@
               }
             },
             "description" : "Return a score if a drop campaign may be progressed by watching this stream.",
-            "required" : ["type"]
+            "required" : [
+              "type"
+            ]
           }
         ]
       }

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/config/AnalyticsConfiguration.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/config/AnalyticsConfiguration.java
@@ -25,8 +25,8 @@ public class AnalyticsConfiguration{
 	@JsonPropertyDescription("Database settings.")
 	@Nullable
 	private DatabaseConfiguration database;
-	@JsonProperty("recordChatsPredictions")
+	@JsonProperty("recordUserPredictions")
 	@JsonPropertyDescription("Record other chat members predictions. Default: false")
 	@Builder.Default
-	private boolean recordChatsPredictions = false;
+	private boolean recordUserPredictions = false;
 }

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/database/DatabaseEventHandler.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/database/DatabaseEventHandler.java
@@ -30,7 +30,8 @@ public class DatabaseEventHandler extends EventHandlerAdapter{
 	private static final double INFINITE_RETURN_RATIO = 100_000D;
 	
 	@NotNull
-	private IDatabase database;
+	private final IDatabase database;
+	private final boolean recordUserPredictions;
 	
 	@Override
 	public void onEventCreatedEvent(@NotNull EventCreatedEvent event) throws Exception{
@@ -44,10 +45,12 @@ public class DatabaseEventHandler extends EventHandlerAdapter{
 		
 		if(predictionEvent.getStatus() == EventStatus.ACTIVE){
 			log.debug("Prediction-Update: Event ACTIVE. Streamer: {}, Title: {}", streamerUsername, predictionEvent.getTitle());
-			for(var outcome : predictionEvent.getOutcomes()){
-				var badge = outcome.getBadge().getVersion();
-				for(var predictor : outcome.getTopPredictors()){
-					database.addUserPrediction(predictor.getUserDisplayName(), event.getEvent().getChannelId(), badge);
+			if(recordUserPredictions){
+				for(var outcome : predictionEvent.getOutcomes()){
+					var badge = outcome.getBadge().getVersion();
+					for(var predictor : outcome.getTopPredictors()){
+						database.addUserPrediction(predictor.getUserDisplayName(), event.getEvent().getChannelId(), badge);
+					}
 				}
 			}
 		}

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/factory/DatabaseFactory.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/factory/DatabaseFactory.java
@@ -88,7 +88,7 @@ public class DatabaseFactory{
     }
     
     @NotNull
-    public static DatabaseEventHandler createDatabaseHandler(@NotNull IDatabase database){
-        return new DatabaseEventHandler(database);
+    public static DatabaseEventHandler createDatabaseHandler(@NotNull IDatabase database, boolean recordUserPredictions){
+	    return new DatabaseEventHandler(database, recordUserPredictions);
     }
 }

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/factory/MinerFactory.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/factory/MinerFactory.java
@@ -47,7 +47,7 @@ public class MinerFactory{
 				}
 				
 				database.deleteAllUserPredictions();
-				miner.addEventHandler(DatabaseFactory.createDatabaseHandler(database));
+				miner.addEventHandler(DatabaseFactory.createDatabaseHandler(database, config.getAnalytics().isRecordUserPredictions()));
 			}
 			
 			return miner;

--- a/miner/src/main/java/fr/rakambda/channelpointsminer/miner/miner/Miner.java
+++ b/miner/src/main/java/fr/rakambda/channelpointsminer/miner/miner/Miner.java
@@ -153,7 +153,7 @@ public class Miner implements AutoCloseable, IMiner, ITwitchPubSubMessageListene
 	private void login(){
 		try{
 			var analyticsConfiguration = accountConfiguration.getAnalytics();
-			var listenMessages = analyticsConfiguration.isEnabled() && analyticsConfiguration.isRecordChatsPredictions();
+			var listenMessages = analyticsConfiguration.isEnabled() && analyticsConfiguration.isRecordUserPredictions();
 			
 			twitchLogin = passportApi.login();
 			

--- a/miner/src/test/java/fr/rakambda/channelpointsminer/miner/database/DatabaseEventHandlerTest.java
+++ b/miner/src/test/java/fr/rakambda/channelpointsminer/miner/database/DatabaseEventHandlerTest.java
@@ -387,6 +387,21 @@ class DatabaseEventHandlerTest{
 	}
 	
 	@Test
+	void onActivePredictionUpdateWithoutUserPredictions() throws SQLException{
+		tested = new DatabaseEventHandler(database, false);
+		
+		var event = mock(EventUpdatedEvent.class);
+		
+		when(event.getEvent()).thenReturn(eventData);
+		
+		when(eventData.getStatus()).thenReturn(EventStatus.ACTIVE);
+		
+		assertDoesNotThrow(() -> tested.onEvent(event));
+		
+		verify(database, never()).addUserPrediction(anyString(), anyString(), anyString());
+	}
+	
+	@Test
 	void onCancelledPredictionUpdate() throws SQLException{
 		var event = mock(EventUpdatedEvent.class);
 		

--- a/miner/src/test/java/fr/rakambda/channelpointsminer/miner/database/DatabaseEventHandlerTest.java
+++ b/miner/src/test/java/fr/rakambda/channelpointsminer/miner/database/DatabaseEventHandlerTest.java
@@ -23,7 +23,6 @@ import fr.rakambda.channelpointsminer.miner.event.impl.StreamUpEvent;
 import fr.rakambda.channelpointsminer.miner.event.impl.StreamerAddedEvent;
 import fr.rakambda.channelpointsminer.miner.handler.data.PlacedPrediction;
 import fr.rakambda.channelpointsminer.miner.tests.ParallelizableTest;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.junit.jupiter.api.BeforeEach;
@@ -69,7 +68,6 @@ class DatabaseEventHandlerTest{
 	private final static String BADGE_PREDICTION_INFO = "badges=predictions/color,sub";
 	private final static String BADGE_NO_PREDICTION_INFO = "badges=sub";
 	
-	@InjectMocks
 	private DatabaseEventHandler tested;
 	
 	@Mock
@@ -114,6 +112,8 @@ class DatabaseEventHandlerTest{
 		lenient().when(predictor4.getUserDisplayName()).thenReturn(USERNAME4);
 		lenient().when(blueOutcome.getTopPredictors()).thenReturn(List.of(predictor1, predictor2));
 		lenient().when(pinkOutcome.getTopPredictors()).thenReturn(List.of(predictor3, predictor4));
+		
+		tested = new DatabaseEventHandler(database, true);
 	}
 	
 	@Test

--- a/miner/src/test/java/fr/rakambda/channelpointsminer/miner/factory/ConfigurationFactoryTest.java
+++ b/miner/src/test/java/fr/rakambda/channelpointsminer/miner/factory/ConfigurationFactoryTest.java
@@ -116,7 +116,7 @@ class ConfigurationFactoryTest{
 						.reloadEvery(15)
 						.analytics(AnalyticsConfiguration.builder()
 								.enabled(true)
-								.recordChatsPredictions(true)
+								.recordUserPredictions(true)
 								.database(DatabaseConfiguration.builder()
 										.jdbcUrl("jdbcUrl")
 										.username("user")

--- a/miner/src/test/java/fr/rakambda/channelpointsminer/miner/factory/DatabaseFactoryTest.java
+++ b/miner/src/test/java/fr/rakambda/channelpointsminer/miner/factory/DatabaseFactoryTest.java
@@ -63,7 +63,7 @@ class DatabaseFactoryTest{
 	void createDatabaseHandler(){
 		var database = mock(IDatabase.class);
 		
-		var handler = DatabaseFactory.createDatabaseHandler(database);
+		var handler = DatabaseFactory.createDatabaseHandler(database, false);
 		assertThat(handler).isNotNull();
 	}
 }

--- a/miner/src/test/java/fr/rakambda/channelpointsminer/miner/factory/MinerFactoryTest.java
+++ b/miner/src/test/java/fr/rakambda/channelpointsminer/miner/factory/MinerFactoryTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class MinerFactoryTest{
 	private static final String USERNAME = "username";
+	private static final boolean RECORD_USER_PREDICTIONS = false;
 	
 	@Mock
 	private AccountConfiguration accountConfiguration;
@@ -63,6 +64,7 @@ class MinerFactoryTest{
 		lenient().when(accountConfiguration.getLoginMethod()).thenReturn(loginMethod);
 		lenient().when(accountConfiguration.getDiscord()).thenReturn(discordConfiguration);
 		lenient().when(accountConfiguration.getAnalytics()).thenReturn(analyticsConfiguration);
+		lenient().when(analyticsConfiguration.isRecordUserPredictions()).thenReturn(RECORD_USER_PREDICTIONS);
 	}
 	
 	@Test
@@ -125,7 +127,7 @@ class MinerFactoryTest{
 				var databaseFactory = mockStatic(DatabaseFactory.class)){
 			apiFactory.when(() -> ApiFactory.createLoginProvider(USERNAME, loginMethod)).thenReturn(passportApi);
 			databaseFactory.when(() -> DatabaseFactory.createDatabase(databaseConfiguration)).thenReturn(database);
-			databaseFactory.when(() -> DatabaseFactory.createDatabaseHandler(database)).thenReturn(databaseEventHandler);
+			databaseFactory.when(() -> DatabaseFactory.createDatabaseHandler(database, RECORD_USER_PREDICTIONS)).thenReturn(databaseEventHandler);
 			
 			when(analyticsConfiguration.isEnabled()).thenReturn(true);
 			when(analyticsConfiguration.getDatabase()).thenReturn(databaseConfiguration);

--- a/miner/src/test/java/fr/rakambda/channelpointsminer/miner/miner/MinerTest.java
+++ b/miner/src/test/java/fr/rakambda/channelpointsminer/miner/miner/MinerTest.java
@@ -140,7 +140,7 @@ class MinerTest{
 		lenient().when(accountConfiguration.getVersionProvider()).thenReturn(VERSION_PROVIDER);
 		lenient().when(accountConfiguration.getLoginMethod()).thenReturn(loginMethod);
 		lenient().when(analyticsConfiguration.isEnabled()).thenReturn(false);
-		lenient().when(analyticsConfiguration.isRecordChatsPredictions()).thenReturn(false);
+		lenient().when(analyticsConfiguration.isRecordUserPredictions()).thenReturn(false);
 		
 		lenient().when(passportApi.login()).thenReturn(twitchLogin);
 		lenient().when(streamerSettings.isFollowRaid()).thenReturn(false);
@@ -285,7 +285,7 @@ class MinerTest{
 			runnableFactory.when(() -> MinerRunnableFactory.createStreamerConfigurationReload(tested, streamerSettingsFactory, false)).thenReturn(streamerConfigurationReload);
 			
 			when(analyticsConfiguration.isEnabled()).thenReturn(true);
-			when(analyticsConfiguration.isRecordChatsPredictions()).thenReturn(true);
+			when(analyticsConfiguration.isRecordUserPredictions()).thenReturn(true);
 			
 			assertDoesNotThrow(() -> tested.start());
 			

--- a/miner/src/test/resources/config/config-with-more-customization.json
+++ b/miner/src/test/resources/config/config-with-more-customization.json
@@ -29,7 +29,7 @@
       "reloadEvery" : 15,
       "analytics" : {
         "enabled" : true,
-        "recordChatsPredictions" : true,
+        "recordUserPredictions" : true,
         "database" : {
           "jdbcUrl" : "jdbcUrl",
           "username" : "user",


### PR DESCRIPTION
## Pull Request Etiquette

### Checklist

- [x] Tests have been added in relevant areas
- [x] Corresponding changes made to the documentation (README.adoc) <!-- (if irrelevant check the box too) -->

### Type of change
New Feature
<!-- Choose one from "Bug fix" / "New Feature" / "Breaking change" / "Internal change" -->

## Description

Currently recordChatPredictions  only filters predictions from the chat. Instead recordUserPredictions  will fully enable/disable recording user predictions. This can avoid some load on the DB if this data isn't wanted.
